### PR TITLE
Jpereira eventiterator generic

### DIFF
--- a/falcon-taz/src/main/java/pt/haslab/taz/events/CatIterator.java
+++ b/falcon-taz/src/main/java/pt/haslab/taz/events/CatIterator.java
@@ -1,0 +1,95 @@
+package pt.haslab.taz.events;
+
+/**
+ * Created by joaopereira
+ */
+
+import pt.haslab.taz.causality.CausalPair;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.NoSuchElementException;
+import java.util.PriorityQueue;
+
+public class CatIterator<T extends Comparable>
+                implements Iterator<T>
+{
+    private PriorityQueue<CausalPair<Iterator<T>, T>> eventHeap;
+
+    //keeps track of the last Iterator next'd for the remove method
+    private Iterator<T> lastIt;
+
+    private final Comparator<CausalPair<Iterator<T>, T>> heapOrder =
+                    new Comparator<CausalPair<Iterator<T>, T>>()
+                    {
+                        //doesnt support null arguments
+                        public int compare( CausalPair<Iterator<T>, T> o1,
+                                            CausalPair<Iterator<T>, T> o2 )
+                        {
+                            return o1.getSecond().compareTo( o2.getSecond()) ;
+                        }
+                    };
+
+    public CatIterator(Collection<? extends Iterable<T>> eventIterables)
+    {
+        //Holds the first value of a list and an iterator of the rest of the list
+        eventHeap = new PriorityQueue<CausalPair<Iterator<T>, T>>(eventIterables.size(), heapOrder);
+
+        for ( Iterable<T> eventIterable : eventIterables )
+        {
+            if (eventIterable != null)
+            {
+                Iterator<T> it = eventIterable.iterator();
+                if (it.hasNext())
+                {
+                    T firstElem = it.next();
+                    eventHeap.add(new CausalPair<Iterator<T>, T>(it, firstElem));
+                }
+            }
+        }
+    }
+
+    public boolean hasNext() {
+        return !eventHeap.isEmpty() || ( lastIt != null && lastIt.hasNext());
+    }
+
+    public T next() {
+        if ( !this.hasNext() ) {
+            throw new NoSuchElementException( "There are no more elements" );
+        }
+
+        if ( lastIt != null && lastIt.hasNext() ) {
+            T toInsert = lastIt.next();
+            eventHeap.add(new CausalPair<Iterator<T>, T>(lastIt, toInsert));
+        }
+
+        CausalPair<Iterator<T>, T> heapTop = eventHeap.poll();
+
+        Iterator<T> it = heapTop.getFirst();
+        T next = heapTop.getSecond();
+        lastIt = it;
+
+        return next;
+    }
+
+    public void remove()
+    {
+        if ( lastIt == null )
+        {
+            throw new IllegalStateException();
+        }
+        //removes the last returned element
+        lastIt.remove();
+
+        if( lastIt.hasNext() ) {
+            T firstElem = lastIt.next();
+            eventHeap.add(new CausalPair<Iterator<T>, T>(lastIt, firstElem));
+        }
+
+        lastIt = null;
+    }
+
+}

--- a/falcon-taz/src/main/java/pt/haslab/taz/events/EventIterator.java
+++ b/falcon-taz/src/main/java/pt/haslab/taz/events/EventIterator.java
@@ -1,89 +1,9 @@
 package pt.haslab.taz.events;
 
-/**
- * Created by joaopereira
- */
-
-import pt.haslab.taz.causality.CausalPair;
-
 import java.util.Collection;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.List;
-import java.util.ListIterator;
-import java.util.NoSuchElementException;
-import java.util.PriorityQueue;
 
-public class EventIterator
-                implements Iterator<Event>
-{
-    private PriorityQueue<CausalPair<Iterator<Event>, Event>> eventHeap;
-
-    //keeps track of the last Iterator next'd for the remove method
-    private Iterator<Event> lastIt;
-
-    private final Comparator<CausalPair<Iterator<Event>, Event>> heapOrder =
-                    new Comparator<CausalPair<Iterator<Event>, Event>>()
-                    {
-                        //doesnt support null arguments
-                        public int compare( CausalPair<Iterator<Event>, Event> o1,
-                                            CausalPair<Iterator<Event>, Event> o2 )
-                        {
-                            return (int) ( o1.getSecond().getEventId() - o2.getSecond().getEventId() );
-                        }
-                    };
-
-    public EventIterator(Collection<? extends Iterable<Event>> eventIterables)
-    {
-        //Holds the first value of a list and an iterator of the rest of the list
-        eventHeap = new PriorityQueue<>(eventIterables.size(), heapOrder);
-
-        for ( Iterable<Event> eventIterable : eventIterables )
-        {
-            if (eventIterable != null)
-            {
-                Iterator<Event> it = eventIterable.iterator();
-                if (it.hasNext())
-                {
-                    Event firstElem = it.next();
-                    eventHeap.add(new CausalPair<Iterator<Event>, Event>(it, firstElem));
-                }
-            }
-        }
+public class EventIterator extends CatIterator<Event> {
+    public EventIterator (Collection<? extends Iterable<Event>> eventIterables) {
+       super(eventIterables);
     }
-
-    public boolean hasNext() {
-        return !eventHeap.isEmpty() || ( lastIt != null && lastIt.hasNext());
-    }
-
-    public Event next() {
-        if ( !this.hasNext() ) {
-            throw new NoSuchElementException( "There are no more elements" );
-        }
-
-        if ( lastIt != null && lastIt.hasNext() ) {
-            Event toInsert = lastIt.next();
-            eventHeap.add(new CausalPair<Iterator<Event>, Event>(lastIt, toInsert));
-        }
-
-        CausalPair<Iterator<Event>, Event> heapTop = eventHeap.poll();
-
-        Iterator<Event> it = heapTop.getFirst();
-        Event next = heapTop.getSecond();
-        lastIt = it;
-
-        return next;
-    }
-
-    public void remove()
-    {
-        if ( lastIt == null )
-        {
-            throw new IllegalStateException();
-        }
-        //removes the last returned element
-        lastIt.remove();
-        lastIt = null;
-    }
-
 }

--- a/falcon-taz/src/test/java/pt/haslab/taz/test/CatIteratorTest.java
+++ b/falcon-taz/src/test/java/pt/haslab/taz/test/CatIteratorTest.java
@@ -1,0 +1,58 @@
+package pt.haslab.taz.test;
+
+import org.junit.Test;
+import pt.haslab.taz.events.CatIterator;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+
+public class CatIteratorTest
+{
+    @Test
+    public void testCatIterator1() {
+        List<Integer> l1 = Arrays.asList(1,3,5);
+        List<Integer> l2 = Arrays.asList(2,4,6);
+        CatIterator<Integer> it = new CatIterator<Integer>(Arrays.asList(l1,l2));
+
+        StringBuilder sb = new StringBuilder();
+
+        while ( it.hasNext() ) {
+            sb.append( it.next() + " " );
+        }
+
+        assertTrue( "Concat (1,3,5) with (2,4,6), expecting (1,2,3,4,5,6)",
+                sb.toString().equals("1 2 3 4 5 6 "));
+
+    }
+
+    @Test
+    public void testCatIterator2() {
+        List<Integer> l1 = new ArrayList( Arrays.asList(1,3,5) );
+        List<Integer> l2 = new ArrayList( Arrays.asList(2,4,6) );
+
+        CatIterator<Integer> it = new CatIterator<Integer>(Arrays.asList(l1,l2));
+
+        it.next();
+        it.next();
+        it.remove();
+        it.next();
+        it.remove();
+        it.next();
+        it.next();
+        it.next();
+
+        it = new CatIterator<Integer>(Arrays.asList(l1,l2));
+        StringBuilder sb = new StringBuilder();
+
+        while ( it.hasNext() ) {
+            sb.append( it.next() + " " );
+        }
+
+        assertEquals( "Concat (1,3,5) with (2,4,6) while removing 2 and 3, expecting (1,4,5,6)", "1 4 5 6 ", sb.toString() );
+
+    }
+}


### PR DESCRIPTION
Generalized EventIterator to CatIterator in order to use a class's Natural Ordering and in order to support input collection types (useful due the change from Lists to SortedSets in falcon-taz)