### PR TITLE
Fix message handler parsing

### DIFF
--- a/falcon-taz/src/main/java/pt/haslab/taz/TraceProcessor.java
+++ b/falcon-taz/src/main/java/pt/haslab/taz/TraceProcessor.java
@@ -545,6 +545,9 @@ public enum TraceProcessor
                 Event e = slowIt.next();
                 fastIt.next(); // advance fastIt to follow slowIt
 
+                if(!slowIt.hasNext())
+                    break;
+
                 // A message handler occurs when there is a HANDLERBEGIN event after a RCV event.
                 Event nextEvent = slowIt.next();
                 if ( e.getType() == EventType.RCV && nextEvent !=null && nextEvent.getType() == EventType.HNDLBEG )


### PR DESCRIPTION
This PR fixes a bug that causes falcon-taz to crash when loading traces having `HNDEND` as the last event of a thread. 