### PR TITLE
Fix parsing of traces with message handlers

### DIFF
--- a/falcon-taz/src/main/java/pt/haslab/taz/TraceProcessor.java
+++ b/falcon-taz/src/main/java/pt/haslab/taz/TraceProcessor.java
@@ -60,7 +60,7 @@ public enum TraceProcessor
     public Map<SocketEvent, List<Event>> handlerEvents;
 
     /* set indicating whether a given thread's trace has message handlers */
-    public HashSet<String> hasHandlers;
+    private HashSet<String> hasHandlers;
 
     /* Map: socket id -> pair of events (connect,accept) */
     public Map<String, CausalPair<SocketEvent, SocketEvent>> connAcptEvents;

--- a/falcon-taz/src/main/java/pt/haslab/taz/TraceProcessor.java
+++ b/falcon-taz/src/main/java/pt/haslab/taz/TraceProcessor.java
@@ -535,7 +535,6 @@ public enum TraceProcessor
             if ( !hasHandlers.contains( thread ) || eventsPerThread.get( thread ).size() <= 1 )
                 continue;
 
-            // Use a fast and a slow iterator to handle nested message handlers while iterating through the thread events.
             SortedSet<Event> threadEvents = eventsPerThread.get( thread );
             Iterator<Event> it = threadEvents.iterator();
 

--- a/falcon-taz/src/main/java/pt/haslab/taz/TraceProcessor.java
+++ b/falcon-taz/src/main/java/pt/haslab/taz/TraceProcessor.java
@@ -550,8 +550,9 @@ public enum TraceProcessor
                 {
                     int nestedCounter = 0;
                     int nextInvocations = 1;
-                    nextEvent = it.next();
                     List<Event> handlerList = new ArrayList<Event>();
+                    handlerList.add(nextEvent); // Save the HANDLERBEGIN event
+                    nextEvent = it.next();
 
                     // Add events to the message handler until reaching the HANDLEREND delimiter.
                     while ( nextEvent != null

--- a/falcon-taz/src/main/java/pt/haslab/taz/TraceProcessor.java
+++ b/falcon-taz/src/main/java/pt/haslab/taz/TraceProcessor.java
@@ -543,10 +543,10 @@ public enum TraceProcessor
             while( slowIt.hasNext() )
             {
                 Event e = slowIt.next();
-                fastIt.next(); // advance fastIt to follow slowIt
-
                 if(!slowIt.hasNext())
                     break;
+
+                fastIt.next(); // advance fastIt to follow slowIt
 
                 // A message handler occurs when there is a HANDLERBEGIN event after a RCV event.
                 Event nextEvent = slowIt.next();

--- a/falcon-taz/src/main/java/pt/haslab/taz/TraceProcessor.java
+++ b/falcon-taz/src/main/java/pt/haslab/taz/TraceProcessor.java
@@ -537,30 +537,27 @@ public enum TraceProcessor
 
             // Use a fast and a slow iterator to handle nested message handlers while iterating through the thread events.
             SortedSet<Event> threadEvents = eventsPerThread.get( thread );
-            Iterator<Event> slowIt = threadEvents.iterator();
-            Iterator<Event> fastIt = threadEvents.iterator();
+            Iterator<Event> it = threadEvents.iterator();
 
             // we already know that this has at least one element
-            Event e = slowIt.next();
-            fastIt.next(); // advance fastIt to follow slowIt
+            Event e = it.next();
 
-            while( slowIt.hasNext() )
+            while( it.hasNext() )
             {
-                Event nextEvent = slowIt.next();
-                fastIt.next(); // advance fastIt to follow slowIt
+                Event nextEvent = it.next();
                 // A message handler occurs when there is a HANDLERBEGIN event after a RCV event.
                 if ( e.getType() == EventType.RCV && nextEvent !=null && nextEvent.getType() == EventType.HNDLBEG )
                 {
                     int nestedCounter = 0;
                     int nextInvocations = 1;
-                    nextEvent = fastIt.next();
+                    nextEvent = it.next();
                     List<Event> handlerList = new ArrayList<Event>();
 
                     // Add events to the message handler until reaching the HANDLEREND delimiter.
                     while ( nextEvent != null
                             && nextEvent.getType() != EventType.HNDLEND
                             && nestedCounter >= 0
-                            && fastIt.hasNext() )
+                            && it.hasNext() )
                     {
                         handlerList.add( nextEvent );
 
@@ -574,13 +571,8 @@ public enum TraceProcessor
                             nestedCounter--; //last HANDLEREND will set nestedCounter to -1 and end the loop
                         }
 
-                        nextEvent = fastIt.next();
+                        nextEvent = it.next();
                         nextInvocations++;
-                    }
-
-                    // Advance slowIt to match fastIt
-                    for (; nextInvocations > 0; nextInvocations--) {
-                        slowIt.next();
                     }
 
                     handlerList.add( nextEvent ); //add HANDLEREND event

--- a/falcon-taz/src/main/java/pt/haslab/taz/TraceProcessor.java
+++ b/falcon-taz/src/main/java/pt/haslab/taz/TraceProcessor.java
@@ -536,27 +536,27 @@ public enum TraceProcessor
                 continue;
 
             SortedSet<Event> threadEvents = eventsPerThread.get( thread );
-            Iterator<Event> it = threadEvents.iterator();
+            Iterator<Event> threadIt = threadEvents.iterator();
 
             // we already know that this has at least one element
-            Event e = it.next();
+            Event e = threadIt.next();
 
-            while( it.hasNext() )
+            while( threadIt.hasNext() )
             {
-                Event nextEvent = it.next();
+                Event nextEvent = threadIt.next();
                 // A message handler occurs when there is a HANDLERBEGIN event after a RCV event.
                 if ( e.getType() == EventType.RCV && nextEvent !=null && nextEvent.getType() == EventType.HNDLBEG )
                 {
                     int nestedCounter = 0;
                     List<Event> handlerList = new ArrayList<Event>();
                     handlerList.add(nextEvent); // Save the HANDLERBEGIN event
-                    nextEvent = it.next();
+                    nextEvent = threadIt.next();
 
                     // Add events to the message handler until reaching the HANDLEREND delimiter.
                     while ( nextEvent != null
                             && nextEvent.getType() != EventType.HNDLEND
                             && nestedCounter >= 0
-                            && it.hasNext() )
+                            && threadIt.hasNext() )
                     {
                         handlerList.add( nextEvent );
 
@@ -570,7 +570,7 @@ public enum TraceProcessor
                             nestedCounter--; //last HANDLEREND will set nestedCounter to -1 and end the loop
                         }
 
-                        nextEvent = it.next();
+                        nextEvent = threadIt.next();
                     }
 
                     handlerList.add( nextEvent ); //add HANDLEREND event

--- a/falcon-taz/src/main/java/pt/haslab/taz/TraceProcessor.java
+++ b/falcon-taz/src/main/java/pt/haslab/taz/TraceProcessor.java
@@ -548,7 +548,6 @@ public enum TraceProcessor
                 if ( e.getType() == EventType.RCV && nextEvent !=null && nextEvent.getType() == EventType.HNDLBEG )
                 {
                     int nestedCounter = 0;
-                    int nextInvocations = 1;
                     List<Event> handlerList = new ArrayList<Event>();
                     handlerList.add(nextEvent); // Save the HANDLERBEGIN event
                     nextEvent = it.next();
@@ -572,7 +571,6 @@ public enum TraceProcessor
                         }
 
                         nextEvent = it.next();
-                        nextInvocations++;
                     }
 
                     handlerList.add( nextEvent ); //add HANDLEREND event

--- a/falcon-taz/src/main/java/pt/haslab/taz/TraceProcessor.java
+++ b/falcon-taz/src/main/java/pt/haslab/taz/TraceProcessor.java
@@ -545,6 +545,9 @@ public enum TraceProcessor
                 Event e = slowIt.next();
                 fastIt.next(); // advance fastIt to follow slowIt
 
+                if(!slowIt.hasNext())
+                    break;
+
                 // A message handler occurs when there is a HANDLERBEGIN event after a RCV event.
                 Event nextEvent = slowIt.next();
                 if ( e.getType() == EventType.RCV && nextEvent !=null && nextEvent.getType() == EventType.HNDLBEG )


### PR DESCRIPTION
This PR fixes a bug that causes falcon-taz to crash when loading traces having message handlers at the end of the execution.

(follow-up on https://github.com/fntneves/falcon/pull/39)